### PR TITLE
removed bson_ext reference

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ source "http://rubygems.org"
 # gem 'ruby-debug19'
 
 gem 'mongoid',  '~> 2.0.0.rc.6'
-gem "bson_ext", ">= 1.1.6"
 
 group :test, :development do
   gem "rspec",  ">= 2.4"

--- a/mongoid_geo.gemspec
+++ b/mongoid_geo.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency  "rspec",          '>= 2.4'
 
   s.add_dependency              "mongoid",        '>= 2.0.0.rc.6'
-  s.add_dependency              "bson_ext",       '>= 1.1.6'
 
   s.add_dependency              'activesupport',  '>= 3.0.4'
   s.add_dependency              'hashie',         '>= 0.4.0'   # https://github.com/okiess/mongo-hashie ???


### PR DESCRIPTION
jJust removed bson_ext from the Gemfile.  As you probably know, bson_ext is an optional include for the mongo drive that boosts performance under mri; however, it's built with native extensions and doesn't work under jruby (which gets its performance boost from a special java version with a jar bundled with the bson gem).  So, basically, removing the bson_ext from your gem's dependencies keeps it from breaking jruby--mri projects will still work and get the boost as long as they include bson_ext in their own gemfile.

Btw, thanks for the gem -- just started using it yesterday.  Only tricky part was figuring out that I needed to define the index in the root collection class, not in the embedded document where my :geo field was defined. 
