### PR TITLE
Fixing bug in to_model and to_models (geo_near.rb)

### DIFF
--- a/lib/mongoid/geo/geo_near.rb
+++ b/lib/mongoid/geo/geo_near.rb
@@ -19,7 +19,7 @@ module Mongoid
 
     module Model
       def to_model
-        m = klass.criteria(_id).first.extend(Mongoid::Geo::Distance)
+        m = klass.criteria.id(_id).first.extend(Mongoid::Geo::Distance)
         m.set_distance distance
         m
       end

--- a/lib/mongoid/geo/geo_near.rb
+++ b/lib/mongoid/geo/geo_near.rb
@@ -19,7 +19,7 @@ module Mongoid
 
     module Model
       def to_model
-        m = klass.where(:_id => _id).first.extend(Mongoid::Geo::Distance)
+        m = klass.criteria(_id).first.extend(Mongoid::Geo::Distance)
         m.set_distance distance
         m
       end

--- a/lib/mongoid/geo/geo_near.rb
+++ b/lib/mongoid/geo/geo_near.rb
@@ -40,7 +40,7 @@ module Mongoid
       
       def to_criteria
         ids = map(&:_id)
-        first.klass.where(:_id.in => ids)
+        first.klass.criteria.id(ids)
       end
     end
 


### PR DESCRIPTION
Here goes a fix for a bug in to_model and to_models.

Basically the two methods wouldn't return any records due to a change in how to query a record in Mongoid with an ID/IDs.

This is my first pull request so you may wanna check it out carefully. :) Tests pass though.
