### PR TITLE
Untitled

### DIFF
--- a/lib/mongoid/geo/fields.rb
+++ b/lib/mongoid/geo/fields.rb
@@ -14,8 +14,8 @@ module Mongoid #:nodoc
             lat_meth = options[:lat] || "lat"
             lng_meth = options[:lng] || "lng"
 
-            define_method(lat_meth) { read_attribute(name)[0] }
-            define_method(lng_meth) { read_attribute(name)[1] }
+            define_method(lat_meth) { read_attribute(name).try(:[],0) }
+            define_method(lng_meth) { read_attribute(name).try(:[],1) }
                         
             define_method "#{lat_meth}=" do |value|
               send(name)[0] = value

--- a/spec/mongoid/geo/geo_fields_spec.rb
+++ b/spec/mongoid/geo/geo_fields_spec.rb
@@ -113,6 +113,8 @@ describe Mongoid::Fields do
     it "should handle nil values" do
       address.location = nil
       address.location.should be_nil
+      address.lat.should      be_nil
+      address.lng.should      be_nil
     end 
   end
 end


### PR DESCRIPTION
when the type of geo field is array,it should also handle the generate methods when the field is nil,
like 
address.lat.should   be_nil 
when address is nil
