### PR TITLE
Gemspec Update to fix Malformed Date

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,8 @@ source "http://rubygems.org"
 # gem 'ruby-debug19'
 
 gem 'mongoid',  '2.0.1'
-gem "bson",     "~> 1.3" # for non jruby apps, require bson_ext in your Gemfile to boost performance
+gem "bson",     ">= 1.3" # for non jruby apps, require bson_ext in your Gemfile to boost performance
 
 group :test, :development do
-  gem "rspec",  "~> 2.5"
+  gem "rspec",  ">= 2.5"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,8 @@ source "http://rubygems.org"
 # gem 'ruby-debug19'
 
 gem 'mongoid',  '2.0.1'
-gem "bson", ">= 1.3" # for non jruby apps, require bson_ext in your Gemfile to boost performance
+gem "bson",     "~> 1.3" # for non jruby apps, require bson_ext in your Gemfile to boost performance
 
 group :test, :development do
-  gem "rspec",  ">= 2.4"
+  gem "rspec",  "~> 2.5"
 end

--- a/mongoid_geo.gemspec
+++ b/mongoid_geo.gemspec
@@ -9,14 +9,14 @@ Gem::Specification.new do |s|
   s.homepage                    = "https://github.com/kristianmandrup/mongoid-geo"
   s.required_rubygems_version   = ">= 1.3.6"
   s.files                       = Dir["lib/**/*"] + ["MIT-LICENSE", "Rakefile", "README.textile"]
+  s.date                        = "2011-04-16"
+  s.add_development_dependency  "rspec",          '>= 2.5'
 
-  s.add_development_dependency  "rspec",          '>= 2.4'
+  s.add_dependency              "mongoid",        '~> 2.0.1'
+  s.add_dependency              "bson",           '~> 1.3'
 
-  s.add_dependency              "mongoid",        '>= 2.0.1'
-  s.add_dependency              "bson",           '>= 1.3'
-
-  s.add_dependency              'activesupport',  '>= 3.0.4'
-  s.add_dependency              'hashie',         '>= 0.4.0'   # https://github.com/okiess/mongo-hashie ???
+  s.add_dependency              'activesupport',  '~> 3.0.6'
+  s.add_dependency              'hashie',         '~> 0.4.0'   # https://github.com/okiess/mongo-hashie ???
 
   s.version                     = "0.4.1"
 end

--- a/mongoid_geo.gemspec
+++ b/mongoid_geo.gemspec
@@ -12,11 +12,11 @@ Gem::Specification.new do |s|
   s.date                        = "2011-04-16"
   s.add_development_dependency  "rspec",          '>= 2.5'
 
-  s.add_dependency              "mongoid",        '~> 2.0.1'
-  s.add_dependency              "bson",           '~> 1.3'
+  s.add_dependency              "mongoid",        '2.0.1'
+  s.add_dependency              "bson",           '>= 1.3'
 
-  s.add_dependency              'activesupport',  '~> 3.0.6'
-  s.add_dependency              'hashie',         '~> 0.4.0'   # https://github.com/okiess/mongo-hashie ???
+  s.add_dependency              'activesupport',  '>= 3.0.6'
+  s.add_dependency              'hashie',         '>= 0.4.0'   # https://github.com/okiess/mongo-hashie ???
 
   s.version                     = "0.4.1"
 end


### PR DESCRIPTION
The gemspec doesn't have a date field, so when including it in a rails project, it will give out a warning due to the date being incorrect - it sets it to Time.now, instead of a Date; rubygem issue as well.
