### PR TITLE
Three small changes

### DIFF
--- a/lib/mongoid/geo/fields.rb
+++ b/lib/mongoid/geo/fields.rb
@@ -18,9 +18,11 @@ module Mongoid #:nodoc
             define_method(lng_meth) { read_attribute(name).try(:[], Mongoid::Geo.lng_index) }
                         
             define_method "#{lat_meth}=" do |value|
+              write_attribute(name, [nil,nil]) if !read_attribute(name).present?
               send(name)[Mongoid::Geo.lat_index] = value
             end            
             define_method "#{lng_meth}=" do |value|
+              write_attribute(name, [nil,nil]) if !read_attribute(name).present?
               send(name)[Mongoid::Geo.lng_index] = value
             end            
           end

--- a/lib/mongoid/geo/point.rb
+++ b/lib/mongoid/geo/point.rb
@@ -11,6 +11,7 @@ module Mongoid::Geo
       when Hash
         return [self[:lat], self[:lng]] if self[:lat]
         return [self[:latitude], self[:longitude]] if self[:latitude]
+        return [self['0'].to_f, self['1'].to_f] if self['0']
         raise "Hash must contain either :lat, :lng or :latitude, :longitude keys to be converted to a geo point"
       when nil
         nil

--- a/spec/mongoid/geo/geo_fields_spec.rb
+++ b/spec/mongoid/geo/geo_fields_spec.rb
@@ -55,6 +55,11 @@ describe Mongoid::Fields do
       address.location.should == [23.5, -49]
     end
     
+    it "should work with point Hash keys 0 and 1" do
+      address.location = {"0" => 41, "1" => -71}
+      address.location.should == [41, -71]
+    end
+    
     
     it "should work with point hashes using the first point only" do
       address.location = [{:lat => 23.5, :lng => -49}, {:lat => 72, :lng => -49}]
@@ -115,6 +120,21 @@ describe Mongoid::Fields do
       address.location.should be_nil
       address.lat.should      be_nil
       address.lng.should      be_nil
-    end 
+    end
+    
+    it "should allow lat then lon assignment when nil" do
+      address.location = nil
+      address.lat = 41
+      address.lng = -71
+      address.location.should == [41, -71]
+    end
+    
+    it "should allow lon then lat assignment when nil" do
+      address.location = nil
+      address.lng = -71
+      address.lat = 41
+      address.location.should == [41, -71]
+    end
+    
   end
 end


### PR DESCRIPTION
1. Allow lat/lng to be assigned independently before the location has been initialized.  For example, <pre><code>p = Place.new; p.lat = 42; p.lng = -72;</code></pre>
2. Allow location to be initialized with a hash that has keys "0" and "1" to support default assignment of an array coming from a multipart post.  That is, when sending a two dimensional array of floats as part of an http multipart post rails passes in the params as a hash with keys "0" and "1".
3. Tweaks to support embedded location objects
### Here are a few tips to get locations working from within embedded documents...
- Both the root class and the embedded location class should include the extend Mongoid::Geo::Near
- Define the index on the root class
- Use the full path to the embedded document's location property (eg, <code>address.location</code>)
- Results from the geo queries will have distance (and the two hashes) defined on the root object

_Example_

```
    class Address
      include Mongoid::Document
      extend Mongoid::Geo::Near
      field :street, :type => String
      field :location, :type => Array, :geo => true, :lat => :latitude, :lng => :longitude
      embedded_in :addressable, :polymorphic => true
    end

    class House
      include Mongoid::Document
      extend Mongoid::Geo::Near
      field :stories, :type => Integer
      embeds_one :address, :as => addressable
      geo_index :'location.coordinates'
    end

    # Search on the root, referencing the embedded location...
    nearest_addresses = House.geoNear(another_address, 'Address.location')
```
