### PR TITLE
Longitude & Latitude Order Matters. This is a very significant bug. Please look over the changes as I am still acclimating to the library and rewriting alot of it in my refactor branch.

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -10,6 +10,13 @@ A Geo extension for Mongoid.
 * Configure and create geo indexes
 * Calculate locations near a given point and return as criteria, sorted by distance
 
+h2. Status Update (May 25, 2011)
+* Fixed major bug which stored coordinate in [:lat, :lng]. This is incorrect. Coordinates must be stored with :lng as the first value in order for geospatial queries to work properly.
+- Excerpt from MongoDB GeoSpatial Indexing
+'The code assumes that you are using decimal degrees in (longitude, latitude) order. This is the same order used for the GeoJSON spec. 
+Using (latitude, longitude) will result in very incorrect results, but is often the ordering used elsewhere, so it is good to double-check.  
+The names you assign to a location object (if using an object and not an array) are completely ignored, only the ordering is detected.'
+
 h2. Status update (May 21, 2011)
 
 * Created alias methods such as _#near_sphere_ for _#nearSphere_ etc. to make the DSL much more 'rubyish'!

--- a/lib/mongoid/geo/point.rb
+++ b/lib/mongoid/geo/point.rb
@@ -1,41 +1,19 @@
 module Mongoid::Geo
   module Point
-    # convert hash or object to [x, y] of floats
     def to_points
-      v = self.kind_of?(Array) ? self.map {|p| p.kind_of?(Fixnum) ? p.to_f : p.extend(Mongoid::Geo::Point).to_point } : self
-      v.flatten
+      coordinates = self.kind_of?(Array) ? self.map{|coordinate| coordinate.to_f} : self.to_point
+      coordinates.flatten
     end
 
     def to_point
       case self
       when Hash
-        return [self[:lat], self[:lng]] if self[:lat]
-        return [self[:latitude], self[:longitude]] if self[:latitude]
-        return [self['0'].to_f, self['1'].to_f] if self['0']
+        return [self[:lng]], self[:lat] if self[:lat] && self.has_key?(:lat) && self.has_key?(:lng)
+        return [self[:longitude], self[:latitude]] if self.has_key?(:longitude) && self.has_key?(:latitude)
         raise "Hash must contain either :lat, :lng or :latitude, :longitude keys to be converted to a geo point"
-      when nil
-        nil
-      when Array
-        self.map(&:to_f)
       else
-        obj   = self.send(:location) if respond_to? :location
-        obj ||= self.send(:position) if self.respond_to? :position
-        obj ||= self
-        get_the_location obj        
+        raise "Invalid Geo Input. Please use either a Hash or an Array. Remember that Longitude must always be the first value in an Array."
       end
-    end
-
-    private
-    
-    def get_the_location obj
-      # if Mongoid::Geo.spherical
-      #   return [obj.lng, obj.lat] if obj.respond_to? :lat
-      #   return [obj.longitude, obj.latitude] if obj.respond_to? :latitude
-      # else
-        return [obj.lat, obj.lng] if obj.respond_to? :lat
-        return [obj.latitude, obj.longitude] if obj.respond_to? :latitude
-      # end
-      obj.to_f
     end
   end
 end


### PR DESCRIPTION
Fixed major bug with the order of longitude and latitude when stored as an array within the document.

Excerpt from MongoDB article on Geospatial Indexing:
"The code assumes that you are using decimal degrees in (longitude, latitude) order. This is the same order used for the GeoJSON spec. Using (latitude, longitude) will result in very incorrect results, but is often the ordering used elsewhere, so it is good to double-check.  The names you assign to a location object (if using an object and not an array) are completely ignored, only the ordering is detected."

Also I took out alot of code. Lets not support developers laziness in providing the proper values to the library. Lets not support any outrageous objects that pass in and expect to be parsed into the correct values. Lets stick with Arrays, correctly ordered with [lng, lat], & Hashes with proper keys such as :lng, :lat or :longitude, :latitude
